### PR TITLE
fix: 大分県のサイト更新でpyppeteerがデフォルトで使ってる古いChroniumでは表示できなくなってたので、新しいのを使うように修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.8.6-slim
 WORKDIR /tmp
 COPY pyproject.toml poetry.lock ./
 
+ENV PYPPETEER_CHROMIUM_REVISION="839847"
+
 RUN apt-get update \
     && apt-get install -y gcc python-dev git \
     # for tabula-py
@@ -10,7 +12,7 @@ RUN apt-get update \
     && pip install --upgrade pip \
     && pip install --no-cache-dir poetry && poetry config virtualenvs.create false && poetry install --no-dev \
     # for pyppeteer
-    && apt-get install -y gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget \
+    && apt-get install -y gconf-service libgbm-dev libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget  \
     && pyppeteer-install \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,4 @@ services:
       - ./:/app
     environment:
       TZ: Asia/Tokyo
+      # PYPPETEER_CHROMIUM_REVISION: 839847

--- a/goto_eat_scrapy/scripts/oita.py
+++ b/goto_eat_scrapy/scripts/oita.py
@@ -143,7 +143,8 @@ class OitaCrawler:
 if __name__ == "__main__":
     """
     usage:
-    $ python -m goto_eat_scrapy.scripts.oita
+    $ PYPPETEER_CHROMIUM_REVISION=839847 python -m goto_eat_scrapy.scripts.oita
+    (無指定で使われるREV=588429のChromium(古い)だと大分県のサイトが表示できなかったので)
     """
 
     crawler = OitaCrawler()


### PR DESCRIPTION
pyppeteerが使ってるChroniumがデフォルトだと`588429`(ver. 71.x)で、これが相当古い。

大分県のサイト更新で依存ライブラリが<a href="https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/globalThis">globalThis</a>を使うようになり、上記Chroniumだと動かなくなっていたので、`PYPPETEER_CHROMIUM_REVISION`を環境変数に指定して、それなりに新しいバージョンのChroniumで動かすようにした。